### PR TITLE
Remove throwable on ExceptionInterface

### DIFF
--- a/src/Prismic/Exception/ExceptionInterface.php
+++ b/src/Prismic/Exception/ExceptionInterface.php
@@ -2,6 +2,6 @@
 
 namespace Prismic\Exception;
 
-interface ExceptionInterface extends \Throwable
+interface ExceptionInterface
 {
 }


### PR DESCRIPTION
Ticket club house : [5384](https://app.clubhouse.io/evaneos/story/5384/supprimer-la-r%C3%A9f%C3%A9rence-%C3%A0-la-class-throwable)

L'interface Throwable est juste pour php7 voir la [doc](https://www.php.net/manual/fr/class.throwable.php)